### PR TITLE
add tests for the interaction between autoproj test and ROCK_TEST_ENABLED

### DIFF
--- a/test/autoproj_test.rb
+++ b/test/autoproj_test.rb
@@ -2,12 +2,12 @@ require_relative 'test_helper'
 
 describe "Autoproj" do
     it "checked out make-based package test dependencies on checkout" do
-        assert File.directory?(package_source_dir('build_tests',
-            'build_tests/autoproj_tests/checkout_of_test_dependencies_make-dep'))
+        assert File.directory?(package_source_dir(
+            'build_tests/autoproj/checkout_of_test_dependencies_make-dep'))
     end
 
     it "checked out ruby-based package test dependencies on checkout" do
-        assert File.directory?(package_source_dir('build_tests',
-            'build_tests/autoproj_tests/checkout_of_test_dependencies_ruby-dep'))
+        assert File.directory?(package_source_dir(
+            'build_tests/autoproj/checkout_of_test_dependencies_ruby-dep'))
     end
 end

--- a/test/rock_core_test.rb
+++ b/test/rock_core_test.rb
@@ -1,0 +1,16 @@
+require_relative 'test_helper'
+
+describe "rock.core package set configuration" do
+    it "builds the test folder if tests are enabled" do
+        # NOTE: all tests are assumed to be enabled by default on the build tests
+        # workspaces
+        assert system("which", "rock-core-enable-tests-successful")
+    end
+
+    it "builds the test folder if tests are enabled" do
+        # NOTE: tests for this package must be disabled in the autoproj
+        # workspace. Use the buildconf seed config.
+        refute system("which", "rock-core-tests-built-if-enabled")
+    end
+end
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,6 +41,10 @@ module Helpers
             flunk("#{library} (resolved as #{library}) does not seem to be linked to #{linked_to} (resolved as #{expected}). Found:\n  #{ldd_results.map { |a, b| "#{a} => #{b}" }.join("\n  ")}")
         end
     end
+
+    def package_source_dir(*package)
+        File.join(ENV['AUTOPROJ_CURRENT_ROOT'], *package)
+    end
 end
 
 Minitest::Test.include Helpers


### PR DESCRIPTION
Depends on:
- [x] https://github.com/rock-core/rock.build-tests-package_set/pull/6

https://github.com/rock-core/autoproj/pull/270 moved the test folder setup in post_import, since the test actually needs the import to have been done. This causes rock.core's overrides.rb to fail, as the setting of ROCK_TEST_ENABLED there is *not* done in post_import.

This adds the test for the functionality itself.